### PR TITLE
Fix handling of missing values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>com.squareup</groupId>
     <artifactId>cascading2-protobuf</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cascading2-protobuf</name>

--- a/src/main/java/com/squareup/cascading2/function/ExtractProto.java
+++ b/src/main/java/com/squareup/cascading2/function/ExtractProto.java
@@ -141,10 +141,14 @@ public class ExtractProto extends BaseOperation implements Function {
       // we've advanced cur all the way to the last Message in the path. the last path element
       // refers to the value, so let's just get what we need from the Message.
       Descriptors.FieldDescriptor desc = fieldDescPath.get(fieldDescPath.size() - 1);
-      if (desc.getJavaType() == Descriptors.FieldDescriptor.JavaType.ENUM) {
-        t.add(((Descriptors.EnumValueDescriptor)cur.getField(desc)).getNumber());
+      if (cur.hasField(desc)) {
+        if (desc.getJavaType() == Descriptors.FieldDescriptor.JavaType.ENUM) {
+          t.add(((Descriptors.EnumValueDescriptor)cur.getField(desc)).getNumber());
+        } else {
+          t.add(cur.getField(desc));
+        }
       } else {
-        t.add(cur.getField(desc));
+        t.add(null);
       }
     }
 

--- a/src/test/java/com/squareup/cascading2/function/ExtractProtoTest.java
+++ b/src/test/java/com/squareup/cascading2/function/ExtractProtoTest.java
@@ -83,6 +83,11 @@ public class ExtractProtoTest extends TestCase {
         exec(new ExtractProto(Example.Partnership.class, "follower.name", "follower.email", "leader.name", "leader.email"), new Tuple(P2)));
   }
 
+  public void testMissingLeaves() throws Exception {
+    assertEquals(new Tuple(null, null),
+        exec(new ExtractProto(Example.Partnership.class, "leader.id", "leader.position"), new Tuple(P2)));
+  }
+
   public void testEnum() throws Exception {
     assertEquals(new Tuple("Jack", "jack@", Example.Person.Position.CEO.getNumber()),
         exec(new ExtractProto(Example.Partnership.class, "leader.name", "leader.email", "leader.position"), new Tuple(P3)));


### PR DESCRIPTION
Currently, this new test fails with:

```
expected:<null    null> but was:<0        1>
```

This is because Protobuf does not (always?) return null from getField when the field is not set. For strings you will get "", for enums a bogus value, for integers 0... This complicates filtering out missing values and has the potential to introduce a lot of bogus information.
