### PR TITLE
Add Serialization for protobuf enum values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>com.squareup</groupId>
     <artifactId>cascading2-protobuf</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>0.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cascading2-protobuf</name>

--- a/src/main/java/com/squareup/cascading2/serialization/ProtobufEnumValueSerialization.java
+++ b/src/main/java/com/squareup/cascading2/serialization/ProtobufEnumValueSerialization.java
@@ -1,0 +1,74 @@
+package com.squareup.cascading2.serialization;
+
+import com.google.protobuf.ProtocolMessageEnum;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.apache.hadoop.io.serializer.Deserializer;
+import org.apache.hadoop.io.serializer.Serialization;
+import org.apache.hadoop.io.serializer.Serializer;
+
+public class ProtobufEnumValueSerialization implements Serialization<ProtocolMessageEnum> {
+  @Override public boolean accept(Class<?> aClass) {
+    return ProtocolMessageEnum.class.isAssignableFrom(aClass);
+  }
+
+  @Override public Serializer<ProtocolMessageEnum> getSerializer(Class<ProtocolMessageEnum> tClass) {
+    return new ProtobufEnumValueSerializer();
+  }
+
+  @Override public Deserializer<ProtocolMessageEnum> getDeserializer(Class<ProtocolMessageEnum> tClass) {
+    return new ProtobufEnumValueDeserializer(tClass);
+  }
+
+  private static class ProtobufEnumValueSerializer implements Serializer<ProtocolMessageEnum> {
+    private DataOutputStream dataOutputStream;
+
+    @Override public void open(OutputStream outputStream) throws IOException {
+      this.dataOutputStream = new DataOutputStream(outputStream);
+    }
+
+    @Override public void serialize(ProtocolMessageEnum enumValue) throws IOException {
+      dataOutputStream.writeInt(enumValue.getNumber());
+    }
+
+    @Override public void close() throws IOException {
+      dataOutputStream.close();
+    }
+  }
+
+  private class ProtobufEnumValueDeserializer implements Deserializer<ProtocolMessageEnum> {
+    private Method valueOf;
+    private DataInputStream dataInputStream;
+
+    public ProtobufEnumValueDeserializer(Class<ProtocolMessageEnum> tClass) {
+      try {
+        valueOf = tClass.getMethod("valueOf", Integer.TYPE);
+      } catch (NoSuchMethodException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override public void open(InputStream inputStream) throws IOException {
+      this.dataInputStream = new DataInputStream(inputStream);
+    }
+
+    @Override public ProtocolMessageEnum deserialize(ProtocolMessageEnum enumValue) throws IOException {
+      try {
+        return (ProtocolMessageEnum)valueOf.invoke(null, this.dataInputStream.readInt());
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(e);
+      } catch (InvocationTargetException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override public void close() throws IOException {
+      dataInputStream.close();
+    }
+  }
+}


### PR DESCRIPTION
This adds another Serialization impl, for the actual enum values (not the enum value descriptors, like ProtobufEnumSerialization).

I used reflection to get at the enum classes "valueOf". Since I only get the method once, I hope it does not add terrible overhead.

By the way, ProtobufEnumSerialization seems incomplete — deserialize returns null. Do we also want serialization for the enum value descriptors? I guess the motivation was that getField for an enum field returns a value descriptor instead of the actual value?
