### PR TITLE
Provide at least one copy of protos with repeated fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>com.squareup</groupId>
     <artifactId>cascading2-protobuf</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cascading2-protobuf</name>

--- a/src/main/java/com/squareup/cascading2/function/ExpandRepeatedProto.java
+++ b/src/main/java/com/squareup/cascading2/function/ExpandRepeatedProto.java
@@ -143,12 +143,18 @@ public class ExpandRepeatedProto <T extends Message> extends BaseOperation imple
     }
 
     Descriptors.FieldDescriptor repeatedField = fieldDescriptorsToExtract[repeatedFieldIndex];
-    for (Object value : (List<Object>) arg.getField(repeatedField)) {
-      Tuple copy = new Tuple(prototypeTuple);
-      copy.set(repeatedFieldIndex, value);
+    List<Object> repeatedValues = (List<Object>) arg.getField(repeatedField);
 
-      functionCall.getOutputCollector().add(copy);
+    if (repeatedValues.size() == 0) {
+      // If there are no copies of the repeated field, return at least one copy of the tuple.
+      functionCall.getOutputCollector().add(prototypeTuple);
+    } else {
+      for (Object value : repeatedValues) {
+        Tuple copy = new Tuple(prototypeTuple);
+        copy.set(repeatedFieldIndex, value);
+
+        functionCall.getOutputCollector().add(copy);
+      }
     }
-
   }
 }


### PR DESCRIPTION
PR #8 added ExpandRepeatedProto, which introduced support for protos with repeated fields by providing one copy of a proto for each value in a repeated field.

Following this logic, if the repeated field had no values, ExpandRepeatedProto would provide exactly 0 copies. This behavior is undesired, as other fields might still contain values. This commit therefore ensures that at least one copy of the proto is returned, even if there aren't any values in the repeated field.
