### PR TITLE
added raw comparator implementation

### DIFF
--- a/src/main/java/com/squareup/cascading2/serialization/ProtobufSerialization.java
+++ b/src/main/java/com/squareup/cascading2/serialization/ProtobufSerialization.java
@@ -6,18 +6,17 @@ import cascading.tuple.hadoop.io.BufferedInputStream;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.Message;
 import com.squareup.cascading2.util.Util;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.io.WritableComparator;
+import org.apache.hadoop.io.serializer.Deserializer;
+import org.apache.hadoop.io.serializer.Serialization;
+import org.apache.hadoop.io.serializer.Serializer;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Comparator;
-import org.apache.hadoop.conf.Configured;
-import org.apache.hadoop.io.WritableComparator;
-import org.apache.hadoop.io.serializer.Deserializer;
-import org.apache.hadoop.io.serializer.Serialization;
-import org.apache.hadoop.io.serializer.Serializer;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class ProtobufSerialization<T extends Message> extends Configured implements Serialization<T>,
     Comparison<T> {

--- a/src/main/java/com/squareup/cascading2/serialization/ProtobufSerialization.java
+++ b/src/main/java/com/squareup/cascading2/serialization/ProtobufSerialization.java
@@ -101,14 +101,7 @@ public class ProtobufSerialization<T extends Message> extends Configured impleme
 
       try {
         int lhsLen = clhs.readRawVarint32();
-//        byte[] lhsBytes = new byte[lhsLen];
-//        lhs.read(lhsBytes, 0, lhsLen);
-
         int rhsLen = crhs.readRawVarint32();
-//        byte[] rhsBytes = new byte[lhsLen];
-//        lhs.read(rhsBytes, 0, rhsLen);
-
-//        return WritableComparator.compareBytes(lhsBytes, 0, lhsLen, rhsBytes, 0, rhsLen);
         return WritableComparator.compareBytes(lhs.getBuffer(), lhs.getPosition(), lhsLen, rhs.getBuffer(), rhs.getPosition(), rhsLen);
       } catch (IOException e) {
         throw new RuntimeException(e);


### PR DESCRIPTION
This adds a new interface implementation to ProtobufComparator that allows us to compare protobuf objects without deserializing them. This should eliminate a major performance bottleneck in any job that uses a protobuf object as a grouping, sorting, or joining key. 
