### PR TITLE
Fix link to github

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
     </properties>
 
     <scm>
-        <url>https://github.com/square/cascading2-protobuf</url>
-        <connection>scm:git:https://github.com/square/cascading2-protobuf</connection>
-        <developerConnection>scm:git:git@github.com:square/cascading2-protobuf.git</developerConnection>
+        <url>https://github.com/square/cascading2-protobufs</url>
+        <connection>scm:git:https://github.com/square/cascading2-protobufs</connection>
+        <developerConnection>scm:git:git@github.com:square/cascading2-protobufs.git</developerConnection>
     </scm>
 
     <licenses>


### PR DESCRIPTION
Fix the link to github.
It's inconsistent with the name of the artifact; so an alternative would be renaming the github project.
